### PR TITLE
Remove from Quarantine AC Test - LRAC-9675

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/BlogsEvents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/BlogsEvents.testcase
@@ -45,9 +45,6 @@ definition {
 	@priority = "3"
 	test CheckBlogClickedTriggeredWhenBlogClicked {
 		property proxy.server.enabled = "true";
-		property portal.upstream = "quarantine";
-
-		// AC Refactor ticket: LRAC-9599
 
 		task ("Get the Property ID in AC") {
 			ACUtils.launchAC();


### PR DESCRIPTION
Removing the test from quarantine because of the fix from [LRAC-9675](https://issues.liferay.com/browse/LRAC-9675).