### PR TITLE
LRAC-10914

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
@@ -1234,7 +1234,7 @@ definition {
 		ACSegments.editWebBehaviorCriterion(
 			indexField = "1",
 			occurenceNumber = "4",
-			searchTerm = "AC Page - Site Name - ${dataSource}");
+			searchTerm = "Blogs AC Title - Site Name - Liferay DXP");
 
 		ACSegments.saveSegment();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
@@ -1195,9 +1195,9 @@ definition {
 
 		var username = "ac";
 
-		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
+		ACUtils.createBlogsAndAddToPage();
 
-		var dataSource = StringUtil.extractFirst("${propertyName}", " ");
+		ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 
 		JSONUser.addUser(
 			userEmailAddress = "${username}@liferay.com",
@@ -1212,6 +1212,8 @@ definition {
 			userLoginFullName = "${username} ${username}");
 
 		ACUtils.navigateToSitePage(
+			actionType = "View Blog",
+			documentTitleList = "Blogs AC Title",
 			pageName = "AC Page",
 			siteName = "Site Name");
 
@@ -1219,7 +1221,7 @@ definition {
 
 		ACUtils.launchAC();
 
-		ACProperties.switchProperty(propertyName = "${propertyName}");
+		ACProperties.switchProperty(propertyName = "${assignedPropertyName}");
 
 		ACNavigation.goToSegments();
 
@@ -1242,11 +1244,11 @@ definition {
 
 		ACUtils.launchDXP(userEmailAddress = "${username}@liferay.com");
 
-		for (var n : list "1,2,3") {
-			ACUtils.navigateToSitePage(
-				pageName = "AC Page",
-				siteName = "Site Name");
-		}
+		ACUtils.navigateToSitePage(
+			actionType = "View Blog",
+			documentTitleList = "Blogs AC Title,Blogs AC Title,Blogs AC Title",
+			pageName = "AC Page",
+			siteName = "Site Name");
 
 		ACUtils.closeAllSessionsAndWait();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
@@ -1191,6 +1191,7 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-9225 | Test Summary: Create a Web Behavior Segment of Viewing a Page"
 	@priority = "4"
 	test CanCreateWebBehaviorSegmentViewingPage {
+		property portal.upstream = "vini";
 		property test.name.skip.portal.instance = "SegmentsCreationWebBehavior#CanCreateWebBehaviorSegmentViewingPage";
 
 		var username = "ac";

--- a/test.properties
+++ b/test.properties
@@ -2671,7 +2671,7 @@
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][analytics-cloud]=\
         (\
             (analytics.cloud.enabled == true) AND \
-            (portal.upstream == true)\
+            (portal.upstream == vini)\
         ) AND \
         (testray.main.component.name == "Analytics Cloud")
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-10914


In CI the page name ends with the data source name, but there the data source name is different from "Liferay DXP" so you need to use `StringUtil.extractFirst`, but only for the segment using the Viewed Page criterion, the name of the page ends with "Liferay DXP". It's a different behavior, but it only happens in the CI and doesn't change the behavior of the test. This is the only test that uses this criterion, I believe that is why we did not observe this difference before.